### PR TITLE
fix: add liquid to Forestry Carpenters internal tank filter, so new liquids are accepted

### DIFF
--- a/src/main/java/modtweaker/mods/forestry/handlers/Carpenter.java
+++ b/src/main/java/modtweaker/mods/forestry/handlers/Carpenter.java
@@ -54,6 +54,7 @@ public class Carpenter {
 	private static class Add extends BaseListAddition {
 		public Add(Recipe recipe) {
 			super("Forestry Carpenter", MachineCarpenter.RecipeManager.recipes, recipe);
+			RecipeManager.recipeFluids.add(recipe.getLiquid().getFluid());
 		}
 	}
 

--- a/src/main/java/modtweaker/mods/forestry/handlers/ThermionicFabricator.java
+++ b/src/main/java/modtweaker/mods/forestry/handlers/ThermionicFabricator.java
@@ -53,6 +53,11 @@ public class ThermionicFabricator {
 	}
 
 	@ZenMethod
+	public static void removeCast(IItemStack product) {
+		MineTweakerAPI.apply(new RemoveCastings(toStack(product)));
+	}
+
+	@ZenMethod
 	public static void removeCasts(IItemStack product) {
 		MineTweakerAPI.apply(new RemoveCastings(toStack(product)));
 	}


### PR DESCRIPTION
otherwise only liquids that forestry are aware, will work.

modified:   src/main/java/modtweaker/mods/forestry/handlers/Carpenter.java

