### PR TITLE
Reworked BaseListRemoval

### DIFF
--- a/src/main/java/modtweaker2/mods/appeng/handlers/Grind.java
+++ b/src/main/java/modtweaker2/mods/appeng/handlers/Grind.java
@@ -41,9 +41,8 @@ public class Grind {
 	}
 
 	private static class Remove extends BaseListRemoval {
-
 		public Remove(ItemStack stack) {
-			super(AEApi.instance().registries().grinder().getRecipes(), stack);
+			super("Applied Energistics 2 Grinder", AEApi.instance().registries().grinder().getRecipes(), stack);
 		}
 
 		@Override
@@ -54,6 +53,11 @@ public class Grind {
 				}
 			}
 			super.apply();
+		}
+		
+		@Override
+		public String getRecipeInfo() {
+		    return stack.getDisplayName();
 		}
 
 	}

--- a/src/main/java/modtweaker2/mods/appeng/handlers/Grind.java
+++ b/src/main/java/modtweaker2/mods/appeng/handlers/Grind.java
@@ -48,17 +48,12 @@ public class Grind {
 
 		@Override
 		public void apply() {
-			ArrayList<IGrinderEntry> toRemove = new ArrayList<IGrinderEntry>();
-
 			for (IGrinderEntry r : AEApi.instance().registries().grinder().getRecipes()) {
 				if (r.getOutput().isItemEqual(stack)) {
-					toRemove.add(r);
+					recipes.add(r);
 				}
 			}
-			for (IGrinderEntry r : toRemove) {
-				AEApi.instance().registries().grinder().getRecipes().remove(r);
-			}
-
+			super.apply();
 		}
 
 	}

--- a/src/main/java/modtweaker2/mods/appeng/handlers/Inscriber.java
+++ b/src/main/java/modtweaker2/mods/appeng/handlers/Inscriber.java
@@ -63,15 +63,12 @@ public class Inscriber {
 
 		@Override
 		public void apply() {
-			ArrayList<IInscriberRecipe> recipesToRemove = new ArrayList<IInscriberRecipe>();
 			for (IInscriberRecipe recipe : AEApi.instance().registries().inscriber().getRecipes()) {
 				if (recipe != null && recipe.getOutput() != null && recipe.getOutput().isItemEqual(stack)) {
-					recipesToRemove.add(recipe);
+					recipes.add(recipe);
 				}
 			}
-			for (IInscriberRecipe recipe : recipesToRemove) {
-				AEApi.instance().registries().inscriber().removeRecipe(recipe);
-			}
+			super.apply();
 		}
 
 	}

--- a/src/main/java/modtweaker2/mods/appeng/handlers/Inscriber.java
+++ b/src/main/java/modtweaker2/mods/appeng/handlers/Inscriber.java
@@ -55,10 +55,8 @@ public class Inscriber {
 	}
 
 	public static class Remove extends BaseListRemoval {
-
 		public Remove(ItemStack stack) {
-
-			super(stack.getUnlocalizedName(), AEApi.instance().registries().inscriber().getRecipes(), stack);
+			super("Applied Energistics 2 Inscriber", AEApi.instance().registries().inscriber().getRecipes(), stack);
 		}
 
 		@Override
@@ -70,7 +68,10 @@ public class Inscriber {
 			}
 			super.apply();
 		}
-
+		
+		@Override
+		public String getRecipeInfo() {
+		    return stack.getUnlocalizedName();
+		}
 	}
-
 }

--- a/src/main/java/modtweaker2/mods/appeng/handlers/Inscriber.java
+++ b/src/main/java/modtweaker2/mods/appeng/handlers/Inscriber.java
@@ -71,7 +71,7 @@ public class Inscriber {
 		
 		@Override
 		public String getRecipeInfo() {
-		    return stack.getUnlocalizedName();
+		    return stack.getDisplayName();
 		}
 	}
 }

--- a/src/main/java/modtweaker2/mods/auracascade/handlers/Pylon.java
+++ b/src/main/java/modtweaker2/mods/auracascade/handlers/Pylon.java
@@ -44,8 +44,6 @@ public class Pylon {
 	}
 
 	private static class Remove extends BaseListRemoval {
-		ArrayList<PylonRecipe> recipesToRemove = new ArrayList<PylonRecipe>();
-
 		public Remove(ItemStack stack) {
 			super(PylonRecipeRegistry.recipes, stack);
 		}
@@ -54,13 +52,11 @@ public class Pylon {
 		public void apply() {
 			for (PylonRecipe r : PylonRecipeRegistry.recipes) {
 				if (r.result.isItemEqual(stack)) {
-					recipesToRemove.add(r);
+					recipes.add(r);
 				}
 			}
 
-			for (PylonRecipe r : recipesToRemove) {
-				recipesToRemove.remove(r);
-			}
+			super.apply();
 		}
 
 	}

--- a/src/main/java/modtweaker2/mods/botania/handlers/Apothecary.java
+++ b/src/main/java/modtweaker2/mods/botania/handlers/Apothecary.java
@@ -59,12 +59,10 @@ public class Apothecary {
         public void apply() {
             for (RecipePetals r : BotaniaAPI.petalRecipes) {
                 if (areEqual(r.getOutput(), stack)) {
-                    recipe = r;
-                    break;
+                    recipes.add(r);
                 }
             }
-
-            BotaniaAPI.petalRecipes.remove(recipe);
+            super.apply();
         }
 
         @Override

--- a/src/main/java/modtweaker2/mods/botania/handlers/ElvenTrade.java
+++ b/src/main/java/modtweaker2/mods/botania/handlers/ElvenTrade.java
@@ -48,12 +48,10 @@ public class ElvenTrade {
         public void apply() {
             for (RecipeElvenTrade r : BotaniaAPI.elvenTradeRecipes) {
                 if (r.getOutput() != null && areEqual(r.getOutput(), stack)) {
-                    recipe = r;
-                    break;
+                    recipes.add(r);
                 }
             }
-
-            BotaniaAPI.elvenTradeRecipes.remove(recipe);
+            super.apply();
         }
 
         @Override

--- a/src/main/java/modtweaker2/mods/botania/handlers/ManaInfusion.java
+++ b/src/main/java/modtweaker2/mods/botania/handlers/ManaInfusion.java
@@ -63,12 +63,10 @@ public class ManaInfusion {
         public void apply() {
             for (RecipeManaInfusion r : BotaniaAPI.manaInfusionRecipes) {
                 if (r.getOutput() != null && areEqual(r.getOutput(), stack)) {
-                    recipe = r;
-                    break;
+                    recipes.add(r);
                 }
             }
-
-            BotaniaAPI.manaInfusionRecipes.remove(recipe);
+            super.apply();
         }
 
         @Override

--- a/src/main/java/modtweaker2/mods/botania/handlers/RuneAltar.java
+++ b/src/main/java/modtweaker2/mods/botania/handlers/RuneAltar.java
@@ -48,12 +48,10 @@ public class RuneAltar {
         public void apply() {
             for (RecipeRuneAltar r : BotaniaAPI.runeAltarRecipes) {
                 if (r.getOutput() != null && areEqual(r.getOutput(), stack)) {
-                    recipe = r;
-                    break;
+                    recipes.add(r);
                 }
             }
-
-            BotaniaAPI.runeAltarRecipes.remove(recipe);
+            super.apply();
         }
 
         @Override

--- a/src/main/java/modtweaker2/mods/extendedworkbench/handlers/ExtendedCrafting.java
+++ b/src/main/java/modtweaker2/mods/extendedworkbench/handlers/ExtendedCrafting.java
@@ -86,13 +86,11 @@ public class ExtendedCrafting {
                 if (o instanceof IExtendedRecipe) {
                     IExtendedRecipe r = (IExtendedRecipe) o;
                     if (r.getRecipeOutput() != null && areEqual((ItemStack) r.getRecipeOutput(), stack)) {
-                        recipe = r;
-                        break;
+                        recipes.add(r);
                     }
                 }
             }
-
-            ExtendedCraftingManager.getInstance().getRecipeList().remove(recipe);
+            super.apply();
         }
 
         @Override

--- a/src/main/java/modtweaker2/mods/factorization/handlers/Crystallizer.java
+++ b/src/main/java/modtweaker2/mods/factorization/handlers/Crystallizer.java
@@ -58,13 +58,11 @@ public class Crystallizer {
                 if (r != null) {
                     ItemStack output = getOutput(r);
                     if (output != null && areEqual(output, stack)) {
-                        recipe = r;
-                        break;
+                        recipes.add(r);
                     }
                 }
             }
-
-            list.remove(recipe);
+            super.apply();
         }
 
         @Override

--- a/src/main/java/modtweaker2/mods/factorization/handlers/Lacerator.java
+++ b/src/main/java/modtweaker2/mods/factorization/handlers/Lacerator.java
@@ -56,12 +56,10 @@ public class Lacerator {
             for (Object r : list) {
                 ItemStack output = getOutput(r);
                 if (output != null && areEqual(output, stack)) {
-                    recipe = r;
-                    break;
+                    recipes.add(r);
                 }
             }
-
-            list.remove(recipe);
+            super.apply();
         }
 
         @Override

--- a/src/main/java/modtweaker2/mods/forestry/handlers/Carpenter.java
+++ b/src/main/java/modtweaker2/mods/forestry/handlers/Carpenter.java
@@ -75,18 +75,16 @@ public class Carpenter {
 
 		public Remove(List list, ItemStack stack) {
 			super("Forestry Carpenter", list, stack);
-
 		}
 
 		@Override
 		public void apply() {
 			for (Recipe r : RecipeManager.recipes) {
 				if (r.getCraftingResult() != null && r.getCraftingResult().isItemEqual(stack)) {
-					recipe = r;
-					break;
+					recipes.add(r);
 				}
 			}
-			RecipeManager.recipes.remove(recipe);
+			super.apply();
 		}
 
 		@Override

--- a/src/main/java/modtweaker2/mods/forestry/handlers/Centrifuge.java
+++ b/src/main/java/modtweaker2/mods/forestry/handlers/Centrifuge.java
@@ -63,11 +63,10 @@ public class Centrifuge {
 		public void apply() {
 			for (Recipe r : RecipeManager.recipes) {
 				if (r.matches(stack)) {
-					recipe = r;
-					RecipeManager.recipes.remove(r);
-					break;
+					recipes.add(r);
 				}
 			}
+			super.apply();
 		}
 
 		@Override

--- a/src/main/java/modtweaker2/mods/forestry/handlers/Fermenter.java
+++ b/src/main/java/modtweaker2/mods/forestry/handlers/Fermenter.java
@@ -54,16 +54,13 @@ public class Fermenter {
 
 		@Override
 		public void apply() {
-			ArrayList<Recipe> recipes = new ArrayList<Recipe>();
 			for (Recipe r : RecipeManager.recipes) {
 				if (r != null && r.resource != null && r.resource.isItemEqual(stack)) {
 					recipes.add(r);
 
 				}
 			}
-			for (Recipe r : recipes) {
-				RecipeManager.recipes.remove(r);
-			}
+			super.apply();
 		}
 
 	}

--- a/src/main/java/modtweaker2/mods/forestry/handlers/Moistener.java
+++ b/src/main/java/modtweaker2/mods/forestry/handlers/Moistener.java
@@ -51,13 +51,10 @@ public class Moistener {
 		public void apply() {
 			for (Recipe r : RecipeManager.recipes) {
 				if (r.product != null && r.product.isItemEqual(stack)) {
-					recipe = r;
-					break;
+					recipes.add(r);
 				}
 			}
-			RecipeManager.recipes.remove(recipe);
-
+			super.apply();
 		}
-
 	}
 }

--- a/src/main/java/modtweaker2/mods/forestry/handlers/Squeezer.java
+++ b/src/main/java/modtweaker2/mods/forestry/handlers/Squeezer.java
@@ -57,12 +57,10 @@ public class Squeezer {
 		public void apply() {
 			for (Recipe r : RecipeManager.recipes) {
 				if (r.liquid != null && r.liquid.isFluidEqual(fluid)) {
-					recipe = r;
-					break;
+					recipes.add(r);
 				}
 			}
-			RecipeManager.recipes.remove(recipe);
-
+			super.apply();
 		}
 
 	}

--- a/src/main/java/modtweaker2/mods/forestry/handlers/Still.java
+++ b/src/main/java/modtweaker2/mods/forestry/handlers/Still.java
@@ -56,13 +56,10 @@ public class Still {
 		public void apply() {
 			for (Recipe r : RecipeManager.recipes) {
 				if (r.output != null && r.output.isFluidEqual(fluid)) {
-					recipe = r;
-					break;
+					recipes.add(r);
 				}
 			}
-			RecipeManager.recipes.remove(recipe);
-
+			super.apply();
 		}
-
 	}
 }

--- a/src/main/java/modtweaker2/mods/mariculture/handlers/Crucible.java
+++ b/src/main/java/modtweaker2/mods/mariculture/handlers/Crucible.java
@@ -62,17 +62,14 @@ public class Crucible {
 		// recipe then removes it
 		@Override
 		public void apply() {
-
 			for (RecipeSmelter r : MaricultureHandlers.crucible.getRecipes()) {
 				if (r != null) {
 					if (r.input != null && stack != null && areEqual(r.input, stack)) {
-						recipe = r;
-						break;
+						recipes.add(r);
 					}
 				}
 			}
-			if (recipe != null)
-				MaricultureHandlers.crucible.getRecipes().remove(recipe);
+			super.apply();
 		}
 
 		@Override

--- a/src/main/java/modtweaker2/mods/mariculture/handlers/Vat.java
+++ b/src/main/java/modtweaker2/mods/mariculture/handlers/Vat.java
@@ -115,18 +115,18 @@ public class Vat {
 				if (r != null)
 					if (r.outputItem != null && stack != null && areEqual(r.outputItem, stack)) {
 						if (r.outputFluid == null || (fluid != null && r.outputFluid.isFluidStackIdentical(fluid))) {
-							recipe = r;
+							recipes.add(r);
 							break;
 						}
 					}
 
 				if ((r.outputFluid != null && fluid != null && r.outputFluid.isFluidStackIdentical(fluid))) {
-					recipe = r;
+					recipes.add(r);
 					break;
 				}
 			}
-			if (recipe != null)
-				MaricultureHandlers.vat.getRecipes().remove(recipe);
+			
+			super.apply();
 		}
 
 		@Override

--- a/src/main/java/modtweaker2/mods/metallurgy/handlers/Alloyer.java
+++ b/src/main/java/modtweaker2/mods/metallurgy/handlers/Alloyer.java
@@ -52,12 +52,10 @@ public class Alloyer {
         public void apply() {
             for (AlloyRecipe r : MetallurgyHelper.alloyerRecipes) {
                 if (r.getCraftingResult() != null && areEqual(r.getCraftingResult(), stack)) {
-                    recipe = r;
-                    break;
+                    recipes.add(r);
                 }
             }
-
-            MetallurgyHelper.alloyerRecipes.remove(recipe);
+            super.apply();
         }
 
         @Override

--- a/src/main/java/modtweaker2/mods/pneumaticcraft/handlers/Assembly.java
+++ b/src/main/java/modtweaker2/mods/pneumaticcraft/handlers/Assembly.java
@@ -68,12 +68,11 @@ public class Assembly {
         public void apply() {
             for (AssemblyRecipe r : (List<AssemblyRecipe>) list) {
                 if (r.getOutput() != null && areEqual(r.getOutput(), stack)) {
-                    recipe = r;
-                    break;
+                    recipes.add(r);
                 }
             }
 
-            list.remove(recipe);
+            super.apply();
         }
 
         @Override

--- a/src/main/java/modtweaker2/mods/pneumaticcraft/handlers/Pressure.java
+++ b/src/main/java/modtweaker2/mods/pneumaticcraft/handlers/Pressure.java
@@ -52,19 +52,17 @@ public class Pressure {
             for (PressureChamberRecipe r : PressureChamberRecipe.chamberRecipes) {
                 boolean matches = true;
                 for (int i = 0; i < stacks.length; i++) {
-                    if (!areEqual(stacks[i], r.output[i])) {
+                    if (!areEqual(stacks[i], r.output[i])) {    // possible IndexOutOfBoundsException on r.output[i]
                         matches = false;
                         break;
                     }
                 }
 
                 if (matches) {
-                    recipe = r;
-                    break;
+                    recipes.add(r);
                 }
             }
-
-            PressureChamberRecipe.chamberRecipes.remove(recipe);
+            super.apply();
         }
 
         @Override

--- a/src/main/java/modtweaker2/mods/railcraft/handlers/BlastFurnace.java
+++ b/src/main/java/modtweaker2/mods/railcraft/handlers/BlastFurnace.java
@@ -46,14 +46,13 @@ public class BlastFurnace {
 
 		@Override
 		public void apply() {
-			ArrayList<IBlastFurnaceRecipe> recipesToRemove = new ArrayList<IBlastFurnaceRecipe>();
 			for (IBlastFurnaceRecipe r : RailcraftHelper.furnace) {
 					if (r.getOutput() != null && stack.isItemEqual(r.getOutput())) {
-						recipesToRemove.add(r);
+						recipes.add(r);
 					}
 			}
-			for (IBlastFurnaceRecipe r : recipesToRemove)
-				RailcraftCraftingManager.blastFurnace.getRecipes().remove(r);
+			
+			super.apply();
 		}
 
 		@Override

--- a/src/main/java/modtweaker2/mods/railcraft/handlers/BlastFurnace.java
+++ b/src/main/java/modtweaker2/mods/railcraft/handlers/BlastFurnace.java
@@ -51,7 +51,6 @@ public class BlastFurnace {
 						recipes.add(r);
 					}
 			}
-			
 			super.apply();
 		}
 

--- a/src/main/java/modtweaker2/mods/railcraft/handlers/CokeOven.java
+++ b/src/main/java/modtweaker2/mods/railcraft/handlers/CokeOven.java
@@ -93,12 +93,10 @@ public class CokeOven {
 		public void apply() {
 			for (ICokeOvenRecipe r : RailcraftHelper.oven) {
 				if (r.getOutput() != null && r.getOutput().getItem().equals(stack)) {
-					recipe = r;
-					break;
+					recipes.add(r);
 				}
 			}
-
-			RailcraftHelper.oven.remove(recipe);
+			super.apply();
 		}
 
 		@Override

--- a/src/main/java/modtweaker2/mods/railcraft/handlers/RockCrusher.java
+++ b/src/main/java/modtweaker2/mods/railcraft/handlers/RockCrusher.java
@@ -49,12 +49,10 @@ public class RockCrusher {
         public void apply() {
             for (IRockCrusherRecipe r : RailcraftHelper.crusher) {
                 if (r.getInput() != null && areEqual(r.getInput(), stack)) {
-                    recipe = r;
-                    break;
+                    recipes.add(r);
                 }
             }
-
-            RailcraftHelper.crusher.remove(recipe);
+            super.apply();
         }
 
         @Override

--- a/src/main/java/modtweaker2/mods/tconstruct/handlers/Casting.java
+++ b/src/main/java/modtweaker2/mods/tconstruct/handlers/Casting.java
@@ -76,18 +76,15 @@ public class Casting {
 
     // Removes all matching recipes, apply is never the same for anything, so will always need to override it
     private static class Remove extends BaseListRemoval {
-        protected final LinkedList<CastingRecipe> removedRecipes;
         protected final RecipeComponent component;
         
         public Remove(ItemStack item, ArrayList list, RecipeComponent component) {
             super("TConstruct Casting", list, item);
-            this.removedRecipes = new LinkedList<CastingRecipe>();
             this.component = component;
         }
         
         public Remove(FluidStack fluid, ArrayList list) {
             super("TConstruct Casting", list, fluid);
-            this.removedRecipes = new LinkedList<CastingRecipe>();
             this.component = RecipeComponent.Material;
         }
 
@@ -96,45 +93,32 @@ public class Casting {
         public void apply() {
             for (Iterator<CastingRecipe> iterator = ((ArrayList<CastingRecipe>)list).iterator(); iterator.hasNext();) {
                 CastingRecipe r = iterator.next();
-                boolean removeRecipie = false;
                 
                 switch(component)
                 {
                     case Cast:
                         if (r.cast != null && areEqual(r.cast, stack)) {
-                            removeRecipie = true;
+                            recipes.add(r);
                         }
 
                         break;
                         
                     case Material:
                         if (r.castingMetal != null && r.castingMetal.isFluidEqual(fluid)) {
-                            removeRecipie = true;
+                            recipes.add(r);
                         }
 
                         break;
                         
                     case Output:
                         if (r.output != null && areEqual(r.output, stack)) {
-                            removeRecipie = true;
+                            recipes.add(r);
                         }
 
                         break;
                 }
-
-                if(removeRecipie) {
-                    iterator.remove();
-                    removedRecipes.add(r);
-                }
             }
-        }
-        
-        @Override
-        public void undo() {
-            for(CastingRecipe recipe : removedRecipes) {
-                this.list.add(recipe);
-            }
-            removedRecipes.clear();
+            super.apply();
         }
 
         @Override

--- a/src/main/java/modtweaker2/mods/tconstruct/handlers/Drying.java
+++ b/src/main/java/modtweaker2/mods/tconstruct/handlers/Drying.java
@@ -55,12 +55,10 @@ public class Drying {
         public void apply() {
             for (DryingRecipe r : (ArrayList<DryingRecipe>) list) {
                 if (r.result != null && areEqual(r.result, stack)) {
-                    recipe = r;
-                    break;
+                    recipes.add(r);
                 }
             }
-
-            list.remove(recipe);
+            super.apply();
         }
 
         @Override

--- a/src/main/java/modtweaker2/mods/tconstruct/handlers/Modifiers.java
+++ b/src/main/java/modtweaker2/mods/tconstruct/handlers/Modifiers.java
@@ -29,12 +29,10 @@ public class Modifiers {
         public void apply() {
             for (ItemModifier m : (List<ItemModifier>) list) {
                 if (m.key.equals(check)) {
-                    recipe = m;
-                    break;
+                    recipes. add(m);
                 }
             }
-
-            list.remove(recipe);
+            super.apply();
         }
     }
 }

--- a/src/main/java/modtweaker2/mods/tconstruct/handlers/Smeltery.java
+++ b/src/main/java/modtweaker2/mods/tconstruct/handlers/Smeltery.java
@@ -72,13 +72,10 @@ public class Smeltery {
 		public void apply() {
 			for (AlloyMix r : TConstructHelper.alloys) {
 					if (r.result != null && fluid != null && r.result.getFluid() == fluid.getFluid()) {
-						recipe = r;
-						break;
+						recipes.add(r);
 					}
 			}
-			if (recipe != null)
-				TConstructHelper.alloys.remove(recipe);
-
+			super.apply();
 		}
 
 		@Override

--- a/src/main/java/modtweaker2/mods/tconstruct/handlers/TiCTweaks.java
+++ b/src/main/java/modtweaker2/mods/tconstruct/handlers/TiCTweaks.java
@@ -98,13 +98,11 @@ public class TiCTweaks {
 				ItemStack clone = new ItemStack(r.item, 1, r.damage);
 				if ((material != null && material.equalsIgnoreCase(r.key)) || (material == null)) {
 					if (clone.isItemEqual(stack)) {
-						recipe = r;
-						break;
+						recipes.add(r);
 					}
 				}
 			}
-
-			PatternBuilder.instance.materials.remove(recipe);
+			super.apply();
 		}
 
 		@Override

--- a/src/main/java/modtweaker2/mods/tfcraft/handlers/Anvil.java
+++ b/src/main/java/modtweaker2/mods/tfcraft/handlers/Anvil.java
@@ -65,15 +65,12 @@ public class Anvil {
 
 		@Override
 		public void apply() {
-			ArrayList<AnvilRecipe> toRemove = new ArrayList<AnvilRecipe>();
 			for (AnvilRecipe recipe : AnvilManager.getInstance().getRecipeList()){
 				if (recipe.getCraftingResult() != null && areEqual(recipe.getCraftingResult(), stack)){
-					toRemove.add(recipe);
+					recipes.add(recipe);
 				}
 			}
-			for (AnvilRecipe aRecipe : toRemove){
-				TFCHelper.anvilRecipes.remove(aRecipe);
-			}
+			super.apply();
 		}
 	}
 	
@@ -84,16 +81,12 @@ public class Anvil {
 		
 		@Override
 		public void apply() {
-			ArrayList<AnvilRecipe> toRemove = new ArrayList<AnvilRecipe>();
 			for (AnvilRecipe recipe : AnvilManager.getInstance().getRecipeList()){
 				if (recipe.getCraftingResult() != null && recipe.getCraftingResult() == stack){
-					toRemove.add(recipe);
+					recipes.add(recipe);
 				}
 			}
-			for (AnvilRecipe aRecipe : toRemove){
-				TFCHelper.anvilWeldRecipes.remove(aRecipe);
-			}
+			super.apply();
 		}
 	}
-
 }

--- a/src/main/java/modtweaker2/mods/tfcraft/handlers/Barrel.java
+++ b/src/main/java/modtweaker2/mods/tfcraft/handlers/Barrel.java
@@ -80,20 +80,17 @@ public class Barrel {
 
 		@Override
 		public void apply() {
-			ArrayList<BarrelRecipe> toRemove = new ArrayList<BarrelRecipe>();
 			for (BarrelRecipe recipe : BarrelManager.getInstance().getRecipes()){
 				if (recipe.getRecipeOutIS() != null && areEqual(recipe.getRecipeOutIS(), stack)){
-					toRemove.add(recipe);
+					recipes.add(recipe);
 				}
 			}
 			for (BarrelRecipe recipe : BarrelManager.getInstance().getRecipes()){
 				if (recipe.getRecipeOutFluid() != null && recipe.getRecipeOutFluid().isFluidEqual(fluid)){
-					toRemove.add(recipe);
+				    recipes.add(recipe);
 				}
 			}
-			for (BarrelRecipe aRecipe : toRemove){
-				TFCHelper.barrelRecipes.remove(aRecipe);
-			}
+			super.apply();
 		}
 	}
 }

--- a/src/main/java/modtweaker2/mods/tfcraft/handlers/Kiln.java
+++ b/src/main/java/modtweaker2/mods/tfcraft/handlers/Kiln.java
@@ -45,17 +45,14 @@ public class Kiln {
 			super("Kiln-Remove", TFCHelper.kilnRecipes, out);
 		}
 
-		@Override
+        @Override
 		public void apply() {
-			ArrayList<KilnRecipe> toRemove = new ArrayList<KilnRecipe>();
 			for (KilnRecipe recipe : KilnCraftingManager.getInstance().getRecipeList()){
 				if (recipe.getCraftingResult() != null && areEqual(recipe.getCraftingResult(), stack)){
-					toRemove.add(recipe);
+					recipes.add(recipe);
 				}
 			}
-			for (KilnRecipe aRecipe : toRemove){
-				TFCHelper.kilnRecipes.remove(aRecipe);
-			}
+			super.apply();
 		}
 	}
 		

--- a/src/main/java/modtweaker2/mods/tfcraft/handlers/Quern.java
+++ b/src/main/java/modtweaker2/mods/tfcraft/handlers/Quern.java
@@ -44,17 +44,27 @@ public class Quern {
 
 		@Override
 		public void apply() {
-			ArrayList<QuernRecipe> toRemove = new ArrayList<QuernRecipe>();
 			for (QuernRecipe recipe : QuernManager.getInstance().getRecipes()){
 				if (recipe.getResult() !=null && areEqual(recipe.getResult(), stack)){
-					toRemove.add(recipe);
+					recipes.add(recipe);
 				}
 			}
-			for (QuernRecipe aRecipe : toRemove){
-				TFCHelper.quernRecipes.remove(aRecipe);
-				TFCHelper.quernVaildItems.remove(aRecipe.getInItem());
+			
+			for (Object aRecipe : recipes){
+			    TFCHelper.quernVaildItems.remove(((QuernRecipe)aRecipe).getInItem());
 			}
+			
+			super.apply();
 		}
+		
+        @Override
+        public void undo() {
+            for (Object aRecipe : recipes){
+                TFCHelper.quernVaildItems.add(((QuernRecipe)aRecipe).getInItem());
+            }
+            
+            super.undo();
+        }
 	}
 	
 }

--- a/src/main/java/modtweaker2/mods/thaumcraft/handlers/Arcane.java
+++ b/src/main/java/modtweaker2/mods/thaumcraft/handlers/Arcane.java
@@ -65,19 +65,15 @@ public class Arcane {
 
 		@Override
 		public void apply() {
-			ArrayList<IArcaneRecipe> recipesToRemove = new ArrayList<IArcaneRecipe>();
 			for (Object o : ThaumcraftApi.getCraftingRecipes()) {
 				if (o != null && o instanceof IArcaneRecipe) {
 					IArcaneRecipe r = (IArcaneRecipe) o;
 					if (r.getRecipeOutput() != null && r.getRecipeOutput().isItemEqual(stack)) {
-						recipesToRemove.add(r);
+						recipes.add(r);
 					}
 				}
 			}
-			for (IArcaneRecipe r : recipesToRemove) {
-				ThaumcraftApi.getCraftingRecipes().remove(r);
-			}
-
+			super.apply();
 		}
 
 		@Override

--- a/src/main/java/modtweaker2/mods/thaumcraft/handlers/Crucible.java
+++ b/src/main/java/modtweaker2/mods/thaumcraft/handlers/Crucible.java
@@ -54,13 +54,11 @@ public class Crucible {
 				if (o instanceof CrucibleRecipe) {
 					CrucibleRecipe r = (CrucibleRecipe) o;
 					if (r.getRecipeOutput() != null && areEqual(r.getRecipeOutput(), stack)) {
-						recipe = r;
-						break;
+						recipes.add(r);
 					}
 				}
 			}
-
-			ThaumcraftApi.getCraftingRecipes().remove(recipe);
+			super.apply();
 		}
 
 		@Override

--- a/src/main/java/modtweaker2/mods/thaumcraft/handlers/Infusion.java
+++ b/src/main/java/modtweaker2/mods/thaumcraft/handlers/Infusion.java
@@ -152,15 +152,10 @@ public class Infusion {
 			}
 			super.apply();
 		}
-
-		@Override
-		public String describe() {
-			return "Removing Infusion Enchantment Recipe: " + enchant.getName();
-		}
-
-		@Override
-		public String describeUndo() {
-			return "Restoring Infusion Enchantment Recipe: " + enchant.getName();
-		}
+		
+        @Override
+        public String getRecipeInfo() {
+            return enchant.getName();
+        }
 	}
 }

--- a/src/main/java/modtweaker2/mods/thaumcraft/handlers/Infusion.java
+++ b/src/main/java/modtweaker2/mods/thaumcraft/handlers/Infusion.java
@@ -119,13 +119,11 @@ public class Infusion {
 				if (o instanceof InfusionRecipe) {
 					InfusionRecipe r = (InfusionRecipe) o;
 					if (r.getRecipeOutput() != null && r.getRecipeOutput() instanceof ItemStack && areEqual((ItemStack) r.getRecipeOutput(), stack)) {
-						recipe = r;
-						break;
+						recipes.add(r);
 					}
 				}
 			}
-
-			ThaumcraftApi.getCraftingRecipes().remove(recipe);
+			super.apply();
 		}
 
 		@Override
@@ -134,25 +132,25 @@ public class Infusion {
 		}
 	}
 
-	private static class RemoveEnchant implements IUndoableAction {
+	private static class RemoveEnchant extends BaseListRemoval {
 		Enchantment enchant;
-		InfusionEnchantmentRecipe removed;
 
 		public RemoveEnchant(Enchantment ench) {
+		    super("Thaumcraft Infusion Enchantment", ThaumcraftApi.getCraftingRecipes());
 			enchant = ench;
 		}
 
 		@Override
 		public void apply() {
-			for (Object recipe : ThaumcraftApi.getCraftingRecipes()) {
+			for (Object recipe : list) {
 				if (recipe instanceof InfusionEnchantmentRecipe) {
 					InfusionEnchantmentRecipe enchRecipe = (InfusionEnchantmentRecipe) recipe;
 					if (enchRecipe.getEnchantment() == enchant) {
-						removed = enchRecipe;
-						ThaumcraftApi.getCraftingRecipes().remove(enchRecipe);
+						recipes.add(enchRecipe);
 					}
 				}
 			}
+			super.apply();
 		}
 
 		@Override
@@ -161,23 +159,8 @@ public class Infusion {
 		}
 
 		@Override
-		public boolean canUndo() {
-			return removed != null;
-		}
-
-		@Override
-		public void undo() {
-			ThaumcraftApi.getCraftingRecipes().add(removed);
-		}
-
-		@Override
 		public String describeUndo() {
 			return "Restoring Infusion Enchantment Recipe: " + enchant.getName();
-		}
-
-		@Override
-		public String getOverrideKey() {
-			return null;
 		}
 	}
 }

--- a/src/main/java/modtweaker2/mods/thaumcraft/handlers/Loot.java
+++ b/src/main/java/modtweaker2/mods/thaumcraft/handlers/Loot.java
@@ -53,23 +53,18 @@ public class Loot {
 	}
 
 	public static class Remove extends BaseListRemoval {
-
 		public Remove(List list, ItemStack stack) {
 			super(list, stack);
 		}
 
 		@Override
 		public void apply() {
-			List<WeightedRandomLoot> loot = (List<WeightedRandomLoot>) list;
-			WeightedRandomLoot remove = null;
-			for (WeightedRandomLoot stack : loot) {
+			for (WeightedRandomLoot stack : (List<WeightedRandomLoot>) list) {
 				if (stack.item.isItemEqual(this.stack)) {
-					remove = stack;
-					break;
+					recipes.add(stack);
 				}
 			}
-			loot.remove(remove);
+			super.apply();
 		}
-
 	}
 }

--- a/src/main/java/modtweaker2/utils/BaseCraftingRemoval.java
+++ b/src/main/java/modtweaker2/utils/BaseCraftingRemoval.java
@@ -16,12 +16,10 @@ public class BaseCraftingRemoval extends BaseListRemoval {
 	public void apply() {
 		for (IRecipe r : (List<IRecipe>) list) {
 			if (r.getRecipeOutput() != null && r.getRecipeOutput() instanceof ItemStack && areEqual(r.getRecipeOutput(), stack)) {
-				recipe = r;
-				break;
+				recipes.add(r);
 			}
 		}
-
-		list.remove(recipe);
+		super.apply();
 	}
 
 	@Override

--- a/src/main/java/modtweaker2/utils/BaseListRemoval.java
+++ b/src/main/java/modtweaker2/utils/BaseListRemoval.java
@@ -4,6 +4,7 @@ import minetweaker.IUndoableAction;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import java.util.LinkedList;
 import java.util.List;
 
 public abstract class BaseListRemoval implements IUndoableAction {
@@ -12,7 +13,7 @@ public abstract class BaseListRemoval implements IUndoableAction {
 
 	protected final FluidStack fluid;
 	protected final ItemStack stack;
-	protected Object recipe;
+	protected final LinkedList recipes = new LinkedList();
 
 	public BaseListRemoval(String description, List list, ItemStack stack, FluidStack fluid) {
 		this.list = list;
@@ -40,16 +41,24 @@ public abstract class BaseListRemoval implements IUndoableAction {
 	public BaseListRemoval(String description, List list) {
 		this(description, list, null, null);
 	}
-
+	
+	@Override
+	public void apply() {
+	    for(Object recipe : recipes) {
+	        list.remove(recipe);
+	    }
+	}
 
 	@Override
 	public boolean canUndo() {
-		return list != null;
+		return list.size() > 0;
 	}
 
 	@Override
 	public void undo() {
-		list.add(recipe);
+	    for(Object recipe : recipes) {
+	        list.add(recipe);
+	    }
 	}
 
 	public String getRecipeInfo() {
@@ -58,19 +67,19 @@ public abstract class BaseListRemoval implements IUndoableAction {
 
 	@Override
 	public String describe() {
-		if (recipe instanceof ItemStack)
-			return "Removing " + description + " Recipe for :" + ((ItemStack) recipe).getDisplayName();
-		else if (recipe instanceof FluidStack)
-			return "Removing " + description + " Recipe for :" + ((FluidStack) recipe).getFluid().getLocalizedName();
+		if (recipes.getFirst() instanceof ItemStack)
+			return "Removing " + description + " Recipe(s) for :" + getItemStackNames(recipes);
+		else if (recipes.getFirst() instanceof FluidStack)
+			return "Removing " + description + " Recipe(s) for :" + getFluidStackNames(recipes);
 		else return "Removing " + description + " Recipe for :" + getRecipeInfo();
 	}
 
 	@Override
 	public String describeUndo() {
-		if (recipe instanceof ItemStack)
-			return "Restoring " + description + " Recipe for :" + ((ItemStack) recipe).getDisplayName();
-		else if (recipe instanceof FluidStack)
-			return "Restoring " + description + " Recipe for :" + ((FluidStack) recipe).getFluid().getLocalizedName();
+		if (recipes.getFirst() instanceof ItemStack)
+			return "Restoring " + description + " Recipe(s) for :" + getItemStackNames(recipes);
+		else if (recipes.getFirst() instanceof FluidStack)
+			return "Restoring " + description + " Recipe(s) for :" + getFluidStackNames(recipes);
 		else return "Restoring " + description + " Recipe for :" + getRecipeInfo();
 	}
 
@@ -78,4 +87,34 @@ public abstract class BaseListRemoval implements IUndoableAction {
 	public Object getOverrideKey() {
 		return null;
 	}
+	
+    private String getItemStackNames(LinkedList list) {
+        if(list.size() == 1)
+            return ((ItemStack)list.getFirst()).getDisplayName();
+
+        StringBuilder sb = new StringBuilder();
+        
+        for(Object entry : list) {
+            sb.append(((ItemStack)entry).getDisplayName()).append(", ");
+        }
+        
+        sb.setLength(sb.length() - 2);
+        
+        return sb.toString();
+    }
+    
+    private String getFluidStackNames(LinkedList list) {
+        if(list.size() == 1)
+            return ((FluidStack)list.getFirst()).getFluid().getLocalizedName();
+
+        StringBuilder sb = new StringBuilder();
+        
+        for(Object entry : list) {
+            sb.append(((FluidStack)entry).getFluid().getLocalizedName()).append(", ");
+        }
+        
+        sb.setLength(sb.length() - 2);
+        
+        return sb.toString();
+    }
 }

--- a/src/main/java/modtweaker2/utils/BaseListRemoval.java
+++ b/src/main/java/modtweaker2/utils/BaseListRemoval.java
@@ -1,6 +1,8 @@
 package modtweaker2.utils;
 
 import minetweaker.IUndoableAction;
+import minetweaker.MineTweakerAPI;
+import modtweaker2.helpers.LogHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -44,6 +46,11 @@ public abstract class BaseListRemoval implements IUndoableAction {
 	
 	@Override
 	public void apply() {
+	    if(recipes.size() == 0) {
+	        MineTweakerAPI.logWarning(String.format("No %s Recipes to remove for: %s", this.description, getRecipeInfo()));
+	        return;
+	    }
+	    
 	    for(Object recipe : recipes) {
 	        list.remove(recipe);
 	    }
@@ -67,20 +74,20 @@ public abstract class BaseListRemoval implements IUndoableAction {
 
 	@Override
 	public String describe() {
-		if (recipes.getFirst() instanceof ItemStack)
-			return "Removing " + description + " Recipe(s) for :" + getItemStackNames(recipes);
-		else if (recipes.getFirst() instanceof FluidStack)
-			return "Removing " + description + " Recipe(s) for :" + getFluidStackNames(recipes);
-		else return "Removing " + description + " Recipe for :" + getRecipeInfo();
+	    if(recipes.size() > 0) {
+            return String.format("Removing %d %s Recipe(s) for: %s", recipes.size(), this.description, getRecipeNames(recipes));
+	    } else {
+	        return String.format("Removing %s Recipe(s) for: %s", this.description, getRecipeInfo());
+	    }
 	}
 
 	@Override
 	public String describeUndo() {
-		if (recipes.getFirst() instanceof ItemStack)
-			return "Restoring " + description + " Recipe(s) for :" + getItemStackNames(recipes);
-		else if (recipes.getFirst() instanceof FluidStack)
-			return "Restoring " + description + " Recipe(s) for :" + getFluidStackNames(recipes);
-		else return "Restoring " + description + " Recipe for :" + getRecipeInfo();
+        if(recipes.size() > 0) {
+            return String.format("Restoring %d %s Recipe(s) for: %s", recipes.size(), this.description, getRecipeNames(recipes));
+        } else {
+            return String.format("No %s Recipes found to restore for: %s", this.description, getRecipeInfo());
+        }
 	}
 
 	@Override
@@ -88,33 +95,39 @@ public abstract class BaseListRemoval implements IUndoableAction {
 		return null;
 	}
 	
-    private String getItemStackNames(LinkedList list) {
-        if(list.size() == 1)
-            return ((ItemStack)list.getFirst()).getDisplayName();
-
-        StringBuilder sb = new StringBuilder();
-        
-        for(Object entry : list) {
-            sb.append(((ItemStack)entry).getDisplayName()).append(", ");
-        }
-        
-        sb.setLength(sb.length() - 2);
-        
-        return sb.toString();
-    }
-    
-    private String getFluidStackNames(LinkedList list) {
-        if(list.size() == 1)
-            return ((FluidStack)list.getFirst()).getFluid().getLocalizedName();
-
-        StringBuilder sb = new StringBuilder();
-        
-        for(Object entry : list) {
-            sb.append(((FluidStack)entry).getFluid().getLocalizedName()).append(", ");
-        }
-        
-        sb.setLength(sb.length() - 2);
-        
-        return sb.toString();
-    }
+	/***
+	 * Returns the names of the recipes inside the list
+	 * @param list which holds the recipes
+	 * @return name or list of names describing the recipe
+	 */
+	private String getRecipeNames(LinkedList list) {
+	    if(list.size() == 0)
+	        return getRecipeInfo();
+	    
+	    if(list.size() == 1) {
+	        if(recipes.getFirst() instanceof ItemStack)
+	            return ((ItemStack)list.getFirst()).getDisplayName();
+	        else if (recipes.getFirst() instanceof FluidStack)
+	            return ((FluidStack)list.getFirst()).getFluid().getLocalizedName();
+	        else
+	            return getRecipeInfo();
+	    }
+	    
+	    StringBuilder sb = new StringBuilder();
+	    
+	    if(recipes.getFirst() instanceof ItemStack) {
+	        for(ItemStack itemStack : (List<ItemStack>)list) {
+	            sb.append(itemStack.getDisplayName()).append(", ");
+	        }
+	    } else if (recipes.getFirst() instanceof FluidStack) {
+	        for(FluidStack fluidStack : (List<FluidStack>)list) {
+	            sb.append(fluidStack.getFluid().getLocalizedName()).append(", ");
+	        }
+	    } else {
+	        sb.append(getRecipeInfo()).append(", ");
+	    }
+	    
+	    sb.setLength(sb.length() - 2);
+	    return sb.toString();
+	}
 }

--- a/src/main/java/modtweaker2/utils/BaseListRemoval.java
+++ b/src/main/java/modtweaker2/utils/BaseListRemoval.java
@@ -58,7 +58,7 @@ public abstract class BaseListRemoval implements IUndoableAction {
 
 	@Override
 	public boolean canUndo() {
-		return list.size() > 0;
+		return recipes.size() > 0;
 	}
 
 	@Override


### PR DESCRIPTION
- Fixes various reasons for crashes if no recipes are removed / recipe object was not used by the classes extending BaseListRemoval. Mostly caused because the undo method is adding a null object (e.g. on /mt reload)
- Added warning if no recipes could be removed (e.g. removing <minecraft:dirt> from BlastFurnace)
- Added option to remove more than 1 recipe with BaseListRemoval, no need for List objects in extending classes. Prepare for wildcard support!
- Cleanup of some classes which are extending BaseListRemoval
