### PR TITLE
Fix for Thermionic Fabricator Cast removal

### DIFF
--- a/src/main/java/modtweaker2/mods/forestry/handlers/ThermionicFabricator.java
+++ b/src/main/java/modtweaker2/mods/forestry/handlers/ThermionicFabricator.java
@@ -82,7 +82,7 @@ public class ThermionicFabricator {
 	    private final RecipeType type;
 		
 		public Remove(ItemStack input, List list, RecipeType type) {
-			super(String.format("Forestry Thermionic Fabricator (%s)", type.toString()), RecipeManager.smeltings, input);
+			super(String.format("Forestry Thermionic Fabricator (%s)", type.toString()), list, input);
 			this.type = type;
 		}
 


### PR DESCRIPTION
- Fixed removing a cast from Thermionic Fabricator will lead to a
ClassCastException exception
- Fix for issue #160 