### PR TITLE
Swap mechanism sawmill input to be checked first before optional output

### DIFF
--- a/src/main/java/modtweaker2/mods/mekanism/handlers/Sawmill.java
+++ b/src/main/java/modtweaker2/mods/mekanism/handlers/Sawmill.java
@@ -69,8 +69,8 @@ public class Sawmill {
             IItemStack outputItem = InputHelper.toIItemStack(entry.getValue().recipeOutput.primaryOutput);
             IItemStack outputItemOptional = InputHelper.toIItemStack(entry.getValue().recipeOutput.secondaryOutput);
             
-            if(!StackHelper.matches(itemOutput, outputItem)) continue;
             if(!StackHelper.matches(itemInput, inputItem)) continue;
+            if(!StackHelper.matches(itemOutput, outputItem)) continue;
             if(!StackHelper.matches(optionalItemOutput, outputItemOptional)) continue;
             
             recipes.put(entry.getKey(), entry.getValue());


### PR DESCRIPTION
Otherwise it finds no recipes to remove, ever.