### PR TITLE
Update mod dependency info for Forestry 4

### DIFF
--- a/src/main/java/modtweaker2/ModProps.java
+++ b/src/main/java/modtweaker2/ModProps.java
@@ -5,5 +5,5 @@ public class ModProps {
 	public static final String NAME = "Mod Tweaker 2", name = NAME;
 	public static final String MODID = "modtweaker2", modid = MODID;
 	public static final String VERSION = "0.9.3", version = VERSION;
-	public static final String DEPENDENCIES = "required-after:MineTweaker3", dependencies = DEPENDENCIES;
+	public static final String DEPENDENCIES = "required-after:MineTweaker3;after:Forestry@[4.0.3,);", dependencies = DEPENDENCIES;
 }


### PR DESCRIPTION
Please pull this once this PR is in: https://github.com/jaredlll08/ModTweaker2/pull/255
It will make sure that *if* Forestry is included, the game will require it to be the correct version.
That way users will get an error message instead of a random crash later if they try to use Forestry 3.6.